### PR TITLE
Buy card endpoint

### DIFF
--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::GamesController < ApplicationController
+  def update
+    game = Game.find(params[:id])
+    player = Player.find(buy_params[:player_id])
+    if game.id == player.game.id
+      buy_params[:bought].each do |card_name, num_bought|
+        num_bought.times do
+          player.buy(card_name)
+        end
+      end
+      render json: {
+        player_name: player.name,
+        bought: buy_params[:bought]
+      }
+    end
+  end
+
+  def buy_params
+    params.require(:buy_info).permit(:player_id, bought: {})
+  end
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,3 +1,12 @@
 class Player < ApplicationRecord
   belongs_to :game
+
+  def cards
+    GameCard.where(player_id: id)
+  end
+
+  def buy(card_name)
+    game_card = GameCard.joins(:card).where('cards.name': card_name, player_id: nil, game_id: game.id).first
+    game_card.update(player_id: id, discarded: true)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'game_state/:id', to: 'game_state#index'
+
+      post 'games/:id/buy_card', to: 'games#update'
     end
   end
 end

--- a/spec/factories/players.rb
+++ b/spec/factories/players.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :player do
     name { "MyString" }
-    deck { nil }
     game { nil }
   end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -4,4 +4,27 @@ RSpec.describe Player, type: :model do
   describe 'relationships' do
     it { should belong_to :game }
   end
+
+  describe 'instance methods' do
+    before :each do
+      @game = create(:game)
+      @player = create(:player, game_id: @game.id)
+      @gold = create(:gold)
+      @estate = create(:estate)
+      create_list(:game_card, 30, game_id: @game.id, card_id: @gold.id)
+      create_list(:game_card, 8, game_id: @game.id, card_id: @estate.id)
+    end
+
+    it '#cards' do
+      expect(@player.cards).to eq([])
+    end
+
+    it '#buy' do
+      expect(@player.cards.length).to eq(0)
+      @player.buy(@gold.name)
+      expect(@player.cards.length).to eq(1)
+      expect(@player.cards.first.card.name).to eq(@gold.name)
+      expect(@game.game_cards.joins(:card).where('cards.name': @gold.name, player_id: nil).length).to eq(29)
+    end
+  end
 end

--- a/spec/requests/buy_card_spec.rb
+++ b/spec/requests/buy_card_spec.rb
@@ -11,22 +11,28 @@ describe 'Buy Card API' do
   end
 
   it 'sends a list of things' do
+    headers = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
     json_payload = {
-      player_id: @player.id,
-      bought: {
-        "Gold": 1,
-        "Estate": 1
+      buy_info: {
+        player_id: @player.id,
+        bought: {
+          "Gold": 1,
+          "Estate": 1
+        }
       }
     }
-    post "/api/v1/games/#{@game.id}/buy_card", params: json_payload.to_json
+    post "/api/v1/games/#{@game.id}/buy_card", headers: headers, params: json_payload.to_json
 
     expect(response).to be_successful
 
     expected_response = {
-      player_name: @player.name,
-      bought: {
-        "Gold": 1,
-        "Estate": 1
+      "player_name" => @player.name,
+      "bought" => {
+        "Gold" => 1,
+        "Estate" => 1
       }
     }
 

--- a/spec/requests/buy_card_spec.rb
+++ b/spec/requests/buy_card_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'Buy Card API' do
+  before :each do
+    @game = create(:game)
+    @player = create(:player, game_id: @game.id)
+    gold = create(:gold)
+    estate = create(:estate)
+    create_list(:game_card, 30, game_id: @game.id, card_id: gold.id)
+    create_list(:game_card, 8, game_id: @game.id, card_id: estate.id)
+  end
+
+  it 'sends a list of things' do
+    json_payload = {
+      player_id: @player.id,
+      bought: {
+        "Gold": 1,
+        "Estate": 1
+      }
+    }
+    post "/api/v1/games/#{@game.id}/buy_card", params: json_payload.to_json
+
+    expect(response).to be_successful
+
+    expected_response = {
+      player_name: @player.name,
+      bought: {
+        "Gold": 1,
+        "Estate": 1
+      }
+    }
+
+    expect(JSON.parse(response.body)).to eq(expected_response)
+  end
+end


### PR DESCRIPTION
## Description

This PR brings in the `buy_card` endpoint, allowing our Frontend to send a request for a specific Player to purchase a Card from the Game pool. This request is sent to `api/v1/games/:game_id/buy_card`, with a body containing `buy_info`, holding the `player_id`, and `bought` attributes. The `bought` object contains one or more Card Names as keys, and number purchased as values.
These are parsed, and a `buy` action is performed on the pertinent Player. The `buy` method takes a Card Name, finds the first matching GameCard in the Players Game, and then changes the `player_id` attribute to the Players ID. For us to see the Players GameCards, we also created an instance method of `cards`, which is a simple scope pulling GameCards that have the `player_id` matching the Players ID.

Resolves #22 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Buy Card Endpoint Spec
- [x] Player Cards Unit Spec
- [x] Player Buy Unit Spec

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
