### PR TITLE
Enable Rack CORS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'active_model_serializers'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       method_source (~> 0.9.0)
     puma (3.12.1)
     rack (2.0.7)
+    rack-cors (1.0.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -205,6 +206,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.3)
   rspec-rails
   sass-rails (~> 5.0)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    # Until we know what domains we need to whitelist
+    origins '*'
+    resource '*', :headers => :any, :methods => :any
+   end
+end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR brings in the `rack-cors` gem to handle any CORS requests from our Frontend team. This sets up the middleware required for Rack to accept these requests, and currently is allowing for all origins, and all types of requests. We will secure this later once we know what domain the FE is being hosted on.

Resolves #66 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
