### PR TITLE
Remove nulls from GameState documentation, fix activePlayerName/activ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ BODY: {
       "name": "Gold",
       "category": ["Money"],
       "cost": 6,
-      "victoryPoints": null,
+      "victoryPoints": 0,
       "spendingPower": 3,
       "buyingPower": 0,
       "actionsProvided": 3,
@@ -164,9 +164,9 @@ BODY: {
       "category": ["Victory"],
       "cost": 2,
       "victoryPoints": 1,
-      "spendingPower": null,
+      "spendingPower": 0,
       "buyingPower": 0,
-      "actionsProvided": null,
+      "actionsProvided": 0,
       "cardsToDraw": 0,
       "image": "./estate.jpg",
       "desc": "",
@@ -180,17 +180,17 @@ BODY: {
   "playerInfo": {
     "Player_1_Name": {
       "deckSize": 10,
-      "topCardDiscard": null,
+      "topCardDiscard": 0,
       "handSize": 5
     },
     "Player_2_Name": {
       "deckSize": 10,
-      "topCardDiscard": null,
+      "topCardDiscard": 0,
       "handSize": 5
     }
   },
-  "currentPlayerName": "Player_1_Name",
-  "currentPlayerId": 1
+  "activePlayerName": "Player_1_Name",
+  "activePlayerId": 1
 }
 ```
 


### PR DESCRIPTION
# Pull Request Template

## Description

Quick fix to resolve two lingering issues on the GameState endpoint documentation.
- Nulls for values on certain attributes of Cards (should be 0's)
- activePlayerName and activePlayerId

Resolves #76 

## Type of change

Please delete options that are not relevant.

- [x] This change is a documentation update

## How Has This Been Tested?

N/A

## Checklist:

- [x] I have made corresponding changes to the documentation
