### PR TITLE
Add strings around HEROKU_STAGING for ENV on Heroku in Seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 if Rails.env.development?
   image_url = "localhost:3000/card_images"
-elsif ENV[HEROKU_STAGING]
+elsif ENV['HEROKU_STAGING']
   image_url = "https://tsdbcg.herokuapp.com/card_images"
 elsif Rails.env.production?
   image_url = "https://tsdbcg.herokuapp.com/card_images"


### PR DESCRIPTION
# Pull Request Template

## Description

We added a `HEROKU_STAGING` environmental variable on Heroku to facilitate the Seeds file making the correct image URL strings on our Card objects. It needs to have strings around it when accessing the `ENV` hash, otherwise Ruby thinks `HEROKU_STAGING` is a constant variable. I was mistaken before when we merged the PR in.

Resolves #82 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
