### PR TITLE
GameState Channel Player Subscription

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'factory_bot_rails'
   gem 'capybara'
+  gem 'action-cable-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    action-cable-testing (0.6.0)
+      actioncable (>= 5.0)
     actioncable (5.2.3)
       actionpack (= 5.2.3)
       nio4r (~> 2.0)
@@ -217,6 +219,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  action-cable-testing
   active_model_serializers
   bootsnap (>= 1.1.0)
   byebug

--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ BODY: {
 }
 ```
 
+## Websockets
+
+### Game State Channel
+- The Game State Channel is the ActionCable websocket that provides up the second information about the current Game State for each Player. This is a work in progress, with only the Player Subscription functionality built out currently.
+```
+connect to '/cable' with parameters of { player_id: 1 }
+```
+- Without a Player ID, the connection will be rejected.
+- On a Player joining, the Channel will return the following information:
+- - Message Type: `player-joined`
+- - Player ID
+- - Player Name
+- The output will be identical to the above `game_state` endpoint, to allow for limited refactoring.
+
 ## Testing
 - Because the Accession Server is built using Rails, the project is set up for testing using the RSpec framework with its robust Rails integration. All tests written are setup inside the spec, there are no required seeds or files to run our test suite.
 - The Accession Server uses SimpleCov to track test coverage on our code. The `coverage` folder that SimpleCov generates is in `.gitignore`, but you should still be able to check coverage by opening the `index.html` files after running the test suite. Code coverage is currently at 100%, so any further contributions should follow this lead.

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -9,8 +9,10 @@ module ApplicationCable
     private
 
     def find_verified_player
-      if verified_player = Player.find(request.params[:player_id])
+      if verified_player = Player.find_by(id: request.params[:player_id])
         verified_player
+      else
+        reject_unauthorized_connection
       end
     end
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,17 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_player
+
+    def connect
+      self.current_player = find_verified_player
+    end
+
+    private
+
+    def find_verified_player
+      if verified_player = Player.find(request.params[:player_id])
+        verified_player
+      end
+    end
   end
 end

--- a/app/channels/game_state_channel.rb
+++ b/app/channels/game_state_channel.rb
@@ -1,0 +1,15 @@
+class GameStateChannel < ApplicationCable::Channel
+  def subscribed
+    ensure_confirmation_sent
+    stream_for current_player.game
+
+    payload = { message: 'Player Joined' }
+    broadcast_message payload
+  end
+
+  private
+
+  def broadcast_message(payload)
+    GameStateChannel.broadcast_to current_player.game, message: payload.to_json
+  end
+end

--- a/app/channels/game_state_channel.rb
+++ b/app/channels/game_state_channel.rb
@@ -3,7 +3,13 @@ class GameStateChannel < ApplicationCable::Channel
     ensure_confirmation_sent
     stream_for current_player.game
 
-    payload = { message: 'Player Joined' }
+    payload = {
+      type: 'player-joined',
+      data: {
+        id: current_player.id,
+        name: current_player.name
+      }
+    }
     broadcast_message payload
   end
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,7 +2,7 @@ development:
   adapter: async
 
 test:
-  adapter: async
+  adapter: test
 
 production:
   adapter: redis

--- a/spec/channels/game_state_channel_spec.rb
+++ b/spec/channels/game_state_channel_spec.rb
@@ -14,4 +14,9 @@ describe GameStateChannel, type: :channel do
     expect(subscription).to be_confirmed
     expect(subscription).to have_stream_for(game)
   end
+
+  it 'broadcasts player info when one player subscribes' do
+    expect{ subscribe }.to have_broadcasted_to(game)
+      .from_channel(GameStateChannel)
+  end
 end

--- a/spec/channels/game_state_channel_spec.rb
+++ b/spec/channels/game_state_channel_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe GameStateChannel, type: :channel do
+  let(:game){Game.create}
+
+  before(:each) do
+    @player = game.players.create(name: 'Testerino')
+    stub_connection current_player: @player
+  end
+
+  it 'subscribes to a game' do
+    subscribe(game_id: @player.game.id)
+
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_for(game)
+  end
+end

--- a/spec/channels/game_state_channel_spec.rb
+++ b/spec/channels/game_state_channel_spec.rb
@@ -18,5 +18,12 @@ describe GameStateChannel, type: :channel do
   it 'broadcasts player info when one player subscribes' do
     expect{ subscribe }.to have_broadcasted_to(game)
       .from_channel(GameStateChannel)
+      .with{ |data|
+        message = JSON.parse(data[:message], symbolize_names: true)
+        expect(message[:type]).to eq('player-joined')
+        payload = message[:data]
+        expect(payload[:id]).to eq(@player.id)
+        expect(payload[:name]).to eq(@player.name)
+      }
   end
 end

--- a/spec/connections/base_spec.rb
+++ b/spec/connections/base_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe ApplicationCable::Connection, type: :channel do
+  it 'successfully connects' do
+    game = Game.create
+    player = game.players.create(name: 'Tortimer')
+    connect('/cable', params: { player_id: player.id })
+    expect(connection.current_player).to eq(player)
+  end
+end

--- a/spec/connections/base_spec.rb
+++ b/spec/connections/base_spec.rb
@@ -7,4 +7,8 @@ describe ApplicationCable::Connection, type: :channel do
     connect('/cable', params: { player_id: player.id })
     expect(connection.current_player).to eq(player)
   end
+
+  it 'rejects connections' do
+    expect { connect '/cable' }.to have_rejected_connection
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,8 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require "action_cable/testing/rspec"
+
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR brings in the initial implementation of our GameStateChannel using Rails' built in ActionCable websocket framework. We are performing testing using the `action-cable-testing` gem, which allows us to stub connections and use helper methods to make better expectations on what our Channel should be doing at any given moment.
This implementation only covers the act of a Player subscribing to a Game at this moment in time. A connection to our Channel is done via a `player_id` parameter. Our Channel then can subscribe this connection to that Players Game, and that game only. 
When a Player creates/joins a Game, and then therefor subscribes to the Game channel, they will receive a broadcast with their own information. If a Player has already joined a Game, and another Player joins after them, that original Player will receive a broadcast of the new Player subscribing/joining to the Game.
During the connection phase of the ActionCable process, if the request does not contain a `player_id`, it will reject the connection.

Resolves #105 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] GameStateChannel can Subscribe spec
- [x] GameStateChannel receives broadcast when subscribing spec
- [x] ActionCable Connection can Connect spec
- [x] ActionCable Connection rejects Connect spec

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
