### PR TITLE
Game State Channel Player List

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ BODY: {
 ## Websockets
 
 ### Game State Channel
-- The Game State Channel is the ActionCable websocket that provides up the second information about the current Game State for each Player. This is a work in progress, with only the Player Subscription functionality built out currently.
+- The Game State Channel is the ActionCable websocket that provides up to the second information about the current Game State for each Player. This is a work in progress, with only the Player Subscription functionality built out currently.
 ```
 connect to '/cable' with parameters of { player_id: 1 }
 ```
@@ -280,6 +280,7 @@ connect to '/cable' with parameters of { player_id: 1 }
 - - Message Type: `player-joined`
 - - Player ID
 - - Player Name
+- - List of Players already in the Game with their IDs and Names
 - The output will be identical to the above `game_state` endpoint, to allow for limited refactoring.
 
 ## Testing

--- a/app/channels/game_state_channel.rb
+++ b/app/channels/game_state_channel.rb
@@ -1,8 +1,18 @@
 class GameStateChannel < ApplicationCable::Channel
+  on_subscribe :broadcast_player_joined
+
   def subscribed
     ensure_confirmation_sent
     stream_for current_player.game
+  end
 
+  private
+
+  def broadcast_message(payload)
+    GameStateChannel.broadcast_to current_player.game, message: payload.to_json
+  end
+
+  def broadcast_player_joined
     payload = {
       type: 'player-joined',
       data: {
@@ -12,12 +22,6 @@ class GameStateChannel < ApplicationCable::Channel
       }
     }
     broadcast_message payload
-  end
-
-  private
-
-  def broadcast_message(payload)
-    GameStateChannel.broadcast_to current_player.game, message: payload.to_json
   end
 
   def player_list_generator(game)

--- a/app/channels/game_state_channel.rb
+++ b/app/channels/game_state_channel.rb
@@ -7,7 +7,8 @@ class GameStateChannel < ApplicationCable::Channel
       type: 'player-joined',
       data: {
         id: current_player.id,
-        name: current_player.name
+        name: current_player.name,
+        playerList: player_list_generator(current_player.game)
       }
     }
     broadcast_message payload
@@ -17,5 +18,14 @@ class GameStateChannel < ApplicationCable::Channel
 
   def broadcast_message(payload)
     GameStateChannel.broadcast_to current_player.game, message: payload.to_json
+  end
+
+  def player_list_generator(game)
+    game.players.map do |player|
+      {
+        id: player.id,
+        name: player.name
+      }
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR brings in the functionality that when a Player subscribes to the GameStateChannel, the subsequent broadcasting message will contain a list of all the Players who have already joined the Game, as an Array of simple objects. The objects contain the Players ID and Name.
This can be used in the frontend to render a list of waiting Players, and also the number of open spots for each of those waiting Players in the Game. This wouldn't be used until we fully implement the Player limit for a Game being 4.
There has also been a refactor for the GameStateChannel to `broadcast_player_joined` on `subscribe`, cleaning up the code using private methods. 

Resolves #106 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] GameStateChannel contains `playerList` information on `subscribe`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
